### PR TITLE
Create Space Selector

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -34,6 +34,11 @@ dependencyManagement {
             entry 'mockserver-client-java'
         }
 
+        dependencySet(group: 'org.mockito', version: '3.12.1') {
+            entry 'mockito-core'
+            entry 'mockito-junit-jupiter'
+        }
+
         // Needed for OpenApi Generate
 
         dependency "io.swagger:swagger-annotations:1.5.24"

--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'
   testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.mockito:mockito-core'
 
   testImplementation 'org.mock-server:mockserver-netty'
   testImplementation 'org.mock-server:mockserver-client-java'

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operations/common/SpaceHomeSelector.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operations/common/SpaceHomeSelector.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.operations.common;
+
+import com.octopus.sdk.api.SpaceHomeApi;
+import com.octopus.sdk.model.spaces.SpaceHome;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SpaceHomeSelector {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final SpaceHomeApi spaceHomeApi;
+
+  public SpaceHomeSelector(final SpaceHomeApi spaceHomeApi) {
+    this.spaceHomeApi = spaceHomeApi;
+  }
+
+  public SpaceHome getSpaceHome(final Optional<String> spaceName) throws IOException {
+    if (spaceName.isPresent()) {
+      LOG.debug("Accessing space '{}'", spaceName);
+      return spaceHomeApi.getByName(spaceName.get());
+    } else {
+      LOG.debug("Accessing default space");
+      return spaceHomeApi.getDefault();
+    }
+  }
+}

--- a/octopus-sdk/src/test/java/com/octopus/sdk/operations/common/SpaceHomeSelectorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/operations/common/SpaceHomeSelectorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.operations.common;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.octopus.sdk.api.SpaceHomeApi;
+import com.octopus.sdk.model.spaces.SpaceHome;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SpaceHomeSelectorTest {
+
+  private final SpaceHomeApi mockSpaceHomeApi = mock(SpaceHomeApi.class);
+  private final SpaceHome defaultSpaceHome = new SpaceHome(emptyMap());
+  private final SpaceHome specificSpaceHome = new SpaceHome(emptyMap());
+
+  @BeforeEach
+  public void setup() throws IOException {
+    when(mockSpaceHomeApi.getByName(any())).thenReturn(specificSpaceHome);
+    when(mockSpaceHomeApi.getDefault()).thenReturn(defaultSpaceHome);
+  }
+
+  @Test
+  public void attemptsToGetDefaultSpaceIfNoNameIsSpecified() throws IOException {
+    final SpaceHomeSelector spaceHomeSelector = new SpaceHomeSelector(mockSpaceHomeApi);
+
+    spaceHomeSelector.getSpaceHome(Optional.empty());
+    verify(mockSpaceHomeApi, times(1)).getDefault();
+    verify(mockSpaceHomeApi, never()).getByName(any());
+  }
+
+  @Test
+  public void attemptsToGetSpaceNameByNameIfNameSpecified() throws IOException {
+    final SpaceHomeSelector spaceHomeSelector = new SpaceHomeSelector(mockSpaceHomeApi);
+    final String spaceName = "spaceName";
+    spaceHomeSelector.getSpaceHome(Optional.of(spaceName));
+    verify(mockSpaceHomeApi, never()).getDefault();
+    verify(mockSpaceHomeApi, times(1)).getByName(eq(spaceName));
+  }
+}


### PR DESCRIPTION
This allows upcoming operations to more easily be tested, and the named/default space selection logic can be tested more simply.