### PR TITLE
Update build gradle to do transient dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,9 +160,12 @@ subprojects {
                     groupId = "com.octopus"
                     version = "${project.version}"
                     from components.java
-                    artifact jar
                     artifact sourcesJar
                     artifact javadocJar
+                    versionMapping {
+                        usage('java-api') { fromResolutionOf('runtimeClasspath') }
+                        usage('java-runtime') { fromResolutionResult() }
+                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ plugins {
     id "com.jfrog.artifactory" version '4.18.0'
     id 'com.adarshr.test-logger' version '3.0.0'
     id 'maven-publish'
-    id 'java'
+    //id 'java'
+    id 'java-library'
     id 'distribution'
 }
 
@@ -47,7 +48,7 @@ def buildAliases = ['dev': [
 ]]
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'net.ltgt.errorprone'
     apply from: "${rootDir}/gradle/versions.gradle"
@@ -158,7 +159,8 @@ subprojects {
             publications {
                 mavenJava(MavenPublication) {
                     groupId = "com.octopus"
-                    version "${project.version}"
+                    version = "${project.version}"
+                    from components.java
                     artifact jar
                     artifact sourcesJar
                     artifact javadocJar

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ plugins {
     id "com.jfrog.artifactory" version '4.18.0'
     id 'com.adarshr.test-logger' version '3.0.0'
     id 'maven-publish'
-    //id 'java'
     id 'java-library'
     id 'distribution'
 }

--- a/octopus-openapi-wrapper/build.gradle
+++ b/octopus-openapi-wrapper/build.gradle
@@ -59,15 +59,15 @@ openApiGenerate {
 }
 
 dependencies {
-  api 'io.swagger:swagger-annotations'
-  api "com.google.code.findbugs:jsr305"
-  api 'com.squareup.okhttp3:okhttp'
-  api 'com.squareup.okhttp3:logging-interceptor'
-  api 'com.google.code.gson:gson'
-  api 'io.gsonfire:gson-fire'
-  api group: 'org.apache.commons', name: 'commons-lang3'
-  api 'io.swagger.parser.v3:swagger-parser-v3'
-  api 'javax.annotation:javax.annotation-api'
+  implementation 'io.swagger:swagger-annotations'
+  implementation "com.google.code.findbugs:jsr305"
+  implementation 'com.squareup.okhttp3:okhttp'
+  implementation 'com.squareup.okhttp3:logging-interceptor'
+  implementation 'com.google.code.gson:gson'
+  implementation 'io.gsonfire:gson-fire'
+  implementation group: 'org.apache.commons', name: 'commons-lang3'
+  implementation 'io.swagger.parser.v3:swagger-parser-v3'
+  implementation 'javax.annotation:javax.annotation-api'
 }
 
 javadoc {

--- a/octopus-openapi-wrapper/build.gradle
+++ b/octopus-openapi-wrapper/build.gradle
@@ -59,15 +59,15 @@ openApiGenerate {
 }
 
 dependencies {
-  implementation 'io.swagger:swagger-annotations'
-  implementation "com.google.code.findbugs:jsr305"
-  implementation 'com.squareup.okhttp3:okhttp'
-  implementation 'com.squareup.okhttp3:logging-interceptor'
-  implementation 'com.google.code.gson:gson'
-  implementation 'io.gsonfire:gson-fire'
-  implementation group: 'org.apache.commons', name: 'commons-lang3'
-  implementation 'io.swagger.parser.v3:swagger-parser-v3'
-  implementation 'javax.annotation:javax.annotation-api'
+  api 'io.swagger:swagger-annotations'
+  api "com.google.code.findbugs:jsr305"
+  api 'com.squareup.okhttp3:okhttp'
+  api 'com.squareup.okhttp3:logging-interceptor'
+  api 'com.google.code.gson:gson'
+  api 'io.gsonfire:gson-fire'
+  api group: 'org.apache.commons', name: 'commons-lang3'
+  api 'io.swagger.parser.v3:swagger-parser-v3'
+  api 'javax.annotation:javax.annotation-api'
 }
 
 javadoc {

--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -28,9 +28,9 @@ tasks.named('jar') {
 dependencies {
   api project(':octopus-openapi-wrapper')
   api 'com.squareup.okhttp3:okhttp'
-  //api 'com.google.code.gson:gson'
-  api 'com.google.guava:guava'
-  api 'org.apache.logging.log4j:log4j-api'
+  implementation 'com.google.code.gson:gson'
+  implementation 'com.google.guava:guava'
+  implementation 'org.apache.logging.log4j:log4j-api'
   runtimeOnly 'org.apache.logging.log4j:log4j-core'
   runtimeOnly 'xerces:xercesImpl'
 

--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -27,11 +27,11 @@ tasks.named('jar') {
 
 dependencies {
   implementation project(':octopus-openapi-wrapper')
-  implementation 'com.squareup.okhttp3:okhttp'
-  implementation 'com.google.code.gson:gson'
-  implementation 'com.google.guava:guava'
-  implementation 'org.apache.logging.log4j:log4j-api'
-  implementation 'org.apache.logging.log4j:log4j-core'
+  api 'com.squareup.okhttp3:okhttp'
+  api 'com.google.code.gson:gson'
+  api 'com.google.guava:guava'
+  api 'org.apache.logging.log4j:log4j-api'
+  api 'org.apache.logging.log4j:log4j-core'
   implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
   runtimeOnly 'xerces:xercesImpl'
 

--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -30,9 +30,8 @@ dependencies {
   api 'com.squareup.okhttp3:okhttp'
   api 'com.google.code.gson:gson'
   api 'com.google.guava:guava'
-  api 'org.apache.logging.log4j:log4j-api'
-  api 'org.apache.logging.log4j:log4j-core'
-  implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
+  implementation 'org.apache.logging.log4j:log4j-api'
+  runtimeOnly 'org.apache.logging.log4j:log4j-core'
   runtimeOnly 'xerces:xercesImpl'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -26,11 +26,11 @@ tasks.named('jar') {
 }
 
 dependencies {
-  implementation project(':octopus-openapi-wrapper')
+  api project(':octopus-openapi-wrapper')
   api 'com.squareup.okhttp3:okhttp'
   api 'com.google.code.gson:gson'
   api 'com.google.guava:guava'
-  implementation 'org.apache.logging.log4j:log4j-api'
+  api 'org.apache.logging.log4j:log4j-api'
   runtimeOnly 'org.apache.logging.log4j:log4j-core'
   runtimeOnly 'xerces:xercesImpl'
 

--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -28,7 +28,7 @@ tasks.named('jar') {
 dependencies {
   api project(':octopus-openapi-wrapper')
   api 'com.squareup.okhttp3:okhttp'
-  api 'com.google.code.gson:gson'
+  //api 'com.google.code.gson:gson'
   api 'com.google.guava:guava'
   api 'org.apache.logging.log4j:log4j-api'
   runtimeOnly 'org.apache.logging.log4j:log4j-core'

--- a/octopus-sdk/src/main/java/com/octopus/sdk/http/Deserialisers.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/http/Deserialisers.java
@@ -23,7 +23,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
-public class Deserialisers {
+class Deserialisers {
 
   public static class OffsetDateTimeDeserialiser implements JsonDeserializer<OffsetDateTime> {
 


### PR DESCRIPTION
This change ensures the pom file of the octopus-sdk contains scoping information for each dependency.
This in turn ensures that when clients of the SDK do not need to explicitly specify underlying dependencies.