### PR TITLE
BuildInformationContext uses Optionals

### DIFF
--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
@@ -17,6 +17,7 @@ package com.octopus.sdk.model;
 
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.annotations.SerializedName;
 
 public class BaseResource {
@@ -29,6 +30,11 @@ public class BaseResource {
 
   public String getId() {
     return id;
+  }
+
+  @VisibleForTesting
+  public void setId(final String id) {
+    this.id = id;
   }
 
   public Map<String, String> getLinks() {

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
@@ -17,7 +17,6 @@ package com.octopus.sdk.model;
 
 import java.util.Map;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.annotations.SerializedName;
 
 public class BaseResource {
@@ -30,11 +29,6 @@ public class BaseResource {
 
   public String getId() {
     return id;
-  }
-
-  @VisibleForTesting
-  public void setId(final String id) {
-    this.id = id;
   }
 
   public Map<String, String> getLinks() {

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploader.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploader.java
@@ -21,6 +21,7 @@ import com.octopus.sdk.api.SpaceHomeApi;
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.sdk.model.buildinformation.BuildInformationResource;
 import com.octopus.sdk.model.buildinformation.OctopusPackageVersionBuildInformation;
+import com.octopus.sdk.model.buildinformation.OctopusPackageVersionBuildInformationMappedResource;
 import com.octopus.sdk.model.spaces.SpaceHome;
 import com.octopus.sdk.operations.common.BaseUploader;
 import com.octopus.sdk.operations.common.SpaceHomeSelector;
@@ -43,16 +44,23 @@ public class BuildInformationUploader extends BaseUploader {
     return new BuildInformationUploader(client, spaceHomeSelector);
   }
 
-  public void upload(final BuildInformationUploaderContext context) throws IOException {
+  /**
+   *
+   * @param context The data to be uploaded, including metadata relating to server connect, and encompassing 'space'
+   * @return The unique identifier of the buildinformation item which was created on the server
+   * @throws IOException
+   */
+  public String upload(final BuildInformationUploaderContext context) throws IOException {
     Preconditions.checkNotNull(context, "Attempted to upload build information with null context.");
 
     final SpaceHome spaceHome = spaceHomeSelector.getSpaceHome(context.getSpaceName());
     final BuildInformationApi buildInfoApi = BuildInformationApi.create(client, spaceHome);
+    final OctopusPackageVersionBuildInformationMappedResource result = uploadToSpace(context, buildInfoApi);
 
-    uploadToSpace(context, buildInfoApi);
+    return result.getId();
   }
 
-  private void uploadToSpace(
+    private OctopusPackageVersionBuildInformationMappedResource uploadToSpace(
       final BuildInformationUploaderContext context, final BuildInformationApi buildInfoApi)
       throws IOException {
     final BuildInformationResource buildInfo = createFrom(context);
@@ -61,7 +69,7 @@ public class BuildInformationUploader extends BaseUploader {
     resource.withVersion(context.getPackageVersion());
     resource.withPackageId(context.getPackageId());
     resource.withBuildInformation(buildInfo);
-    buildInfoApi.create(resource, context.getOverwriteMode());
+    return buildInfoApi.create(resource, context.getOverwriteMode());
   }
 
   private BuildInformationResource createFrom(final BuildInformationUploaderContext context) {
@@ -70,10 +78,10 @@ public class BuildInformationUploader extends BaseUploader {
         .buildNumber(context.getBuildNumber())
         .buildUrl(context.getBuildUrl().toString())
         .buildEnvironment(context.getBuildEnvironment())
-        .branch(context.getBranch())
-        .vcsRoot(context.getVcsRoot())
-        .vcsCommitNumber(context.getVcsCommitNumber())
-        .vcsType(context.getVcsType())
+        .branch(context.getBranch().orElse(null))
+        .vcsRoot(context.getVcsRoot().orElse(null))
+        .vcsCommitNumber(context.getVcsCommitNumber().orElse(null))
+        .vcsType(context.getVcsType().orElse(null))
         .commits(
             context.getCommits().stream()
                 .map(BuildInformationUploader::from)

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploader.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploader.java
@@ -44,23 +44,18 @@ public class BuildInformationUploader extends BaseUploader {
     return new BuildInformationUploader(client, spaceHomeSelector);
   }
 
-  /**
-   *
-   * @param context The data to be uploaded, including metadata relating to server connect, and encompassing 'space'
-   * @return The unique identifier of the buildinformation item which was created on the server
-   * @throws IOException
-   */
   public String upload(final BuildInformationUploaderContext context) throws IOException {
     Preconditions.checkNotNull(context, "Attempted to upload build information with null context.");
 
     final SpaceHome spaceHome = spaceHomeSelector.getSpaceHome(context.getSpaceName());
     final BuildInformationApi buildInfoApi = BuildInformationApi.create(client, spaceHome);
-    final OctopusPackageVersionBuildInformationMappedResource result = uploadToSpace(context, buildInfoApi);
+    final OctopusPackageVersionBuildInformationMappedResource result =
+        uploadToSpace(context, buildInfoApi);
 
     return result.getId();
   }
 
-    private OctopusPackageVersionBuildInformationMappedResource uploadToSpace(
+  private OctopusPackageVersionBuildInformationMappedResource uploadToSpace(
       final BuildInformationUploaderContext context, final BuildInformationApi buildInfoApi)
       throws IOException {
     final BuildInformationResource buildInfo = createFrom(context);

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderContext.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderContext.java
@@ -23,29 +23,28 @@ import java.util.StringJoiner;
 
 public class BuildInformationUploaderContext {
   private final String buildEnvironment;
-  private final String branch;
   private final String buildNumber;
-  private final URL buildUrl;
-  private final String vcsType;
-  private final String vcsRoot;
-  private final String vcsCommitNumber;
+  private final Optional<String> spaceName;
+
+  private final Optional<URL> buildUrl;
+  private final Optional<String> branch;
+  private final Optional<String> vcsType;
+  private final Optional<String> vcsRoot;
+  private final Optional<String> vcsCommitNumber;
 
   private final List<Commit> commits;
-
-  private final Optional<String> spaceName;
   private final String packageId;
   private final String packageVersion;
-
   private final OverwriteMode overwriteMode;
 
   public BuildInformationUploaderContext(
       final String buildEnvironment,
-      final String branch,
+      final Optional<String> branch,
       final String buildNumber,
-      final URL buildUrl,
-      final String vcsType,
-      final String vcsRoot,
-      final String vcsCommitNumber,
+      final Optional<URL> buildUrl,
+      final Optional<String> vcsType,
+      final Optional<String> vcsRoot,
+      final Optional<String> vcsCommitNumber,
       final List<Commit> commits,
       final Optional<String> spaceName,
       final String packageId,
@@ -69,7 +68,7 @@ public class BuildInformationUploaderContext {
     return buildEnvironment;
   }
 
-  public String getBranch() {
+  public Optional<String> getBranch() {
     return branch;
   }
 
@@ -77,19 +76,19 @@ public class BuildInformationUploaderContext {
     return buildNumber;
   }
 
-  public URL getBuildUrl() {
+  public Optional<URL> getBuildUrl() {
     return buildUrl;
   }
 
-  public String getVcsType() {
+  public Optional<String> getVcsType() {
     return vcsType;
   }
 
-  public String getVcsRoot() {
+  public Optional<String> getVcsRoot() {
     return vcsRoot;
   }
 
-  public String getVcsCommitNumber() {
+  public Optional<String> getVcsCommitNumber() {
     return vcsCommitNumber;
   }
 

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderContextBuilder.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderContextBuilder.java
@@ -25,17 +25,17 @@ import java.util.Optional;
 import com.google.common.base.Preconditions;
 
 public class BuildInformationUploaderContextBuilder {
-
   private String buildEnvironment;
-  private String vcsType;
-  private String vcsRoot;
-  private String vcsCommitNumber;
-  private String branch;
-  private List<Commit> commits = emptyList();
-  private URL buildUrl;
   private String buildNumber;
-
   private Optional<String> spaceName = Optional.empty();
+
+  private Optional<URL> buildUrl = Optional.empty();
+  private Optional<String> branch = Optional.empty();
+  private Optional<String> vcsType = Optional.empty();
+  private Optional<String> vcsRoot = Optional.empty();
+  private Optional<String> vcsCommitNumber = Optional.empty();
+
+  private List<Commit> commits;
   private String packageId;
   private String packageVersion;
   private OverwriteMode overwriteMode;
@@ -47,22 +47,22 @@ public class BuildInformationUploaderContextBuilder {
   }
 
   public BuildInformationUploaderContextBuilder withVcsType(final String vcsType) {
-    this.vcsType = vcsType;
+    this.vcsType = Optional.ofNullable(vcsType);
     return this;
   }
 
   public BuildInformationUploaderContextBuilder withVcsRoot(final String vcsRoot) {
-    this.vcsRoot = vcsRoot;
+    this.vcsRoot = Optional.ofNullable(vcsRoot);
     return this;
   }
 
   public BuildInformationUploaderContextBuilder withVcsCommitNumber(final String vcsCommitNumber) {
-    this.vcsCommitNumber = vcsCommitNumber;
+    this.vcsCommitNumber = Optional.ofNullable(vcsCommitNumber);
     return this;
   }
 
   public BuildInformationUploaderContextBuilder withBranch(final String branch) {
-    this.branch = branch;
+    this.branch = Optional.ofNullable(branch);
     return this;
   }
 
@@ -77,7 +77,7 @@ public class BuildInformationUploaderContextBuilder {
   }
 
   public BuildInformationUploaderContextBuilder withBuildUrl(final URL buildUrl) {
-    this.buildUrl = buildUrl;
+    this.buildUrl = Optional.ofNullable(buildUrl);
     return this;
   }
 

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderContextBuilder.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderContextBuilder.java
@@ -14,8 +14,6 @@
  */
 package com.octopus.sdk.operations.buildinformation;
 
-import static java.util.Collections.emptyList;
-
 import com.octopus.sdk.api.OverwriteMode;
 
 import java.net.URL;
@@ -104,10 +102,15 @@ public class BuildInformationUploaderContextBuilder {
 
   public BuildInformationUploaderContext build() {
     Preconditions.checkNotNull(
-        packageVersion, "packageVersion must be set on a build information object");
+        buildEnvironment, "buildEnvironment must be set on a build information context");
     Preconditions.checkNotNull(
-        overwriteMode, "overwriteMode must be set on a build information object");
-    Preconditions.checkNotNull(buildUrl, "buildUrl must be set on a build information object");
+        buildNumber, "buildNumber must be set on a build information context");
+    Preconditions.checkNotNull(commits, "commits must be set on a build information context");
+    Preconditions.checkNotNull(packageId, "packageId must be set on a build information context");
+    Preconditions.checkNotNull(
+        packageVersion, "packageVersion must be set on a build information context");
+    Preconditions.checkNotNull(
+        overwriteMode, "overwriteMode must be set on a build information context");
 
     // The "extra bit on the URL needs to be moved out of here.
     return new BuildInformationUploaderContext(

--- a/octopus-sdk/src/test/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderTest.java
@@ -71,8 +71,8 @@ class BuildInformationUploaderTest {
             .build();
 
     final OctopusPackageVersionBuildInformationMappedResource response =
-        new OctopusPackageVersionBuildInformationMappedResource();
-    response.setId("ObjectId");
+        mock(OctopusPackageVersionBuildInformationMappedResource.class);
+    when(response.getId()).thenReturn("ObjectId");
     when(mockClient.post(any(), any(), any())).thenReturn(response);
 
     final BuildInformationUploader uploader =

--- a/octopus-sdk/src/test/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/operations/buildinformation/BuildInformationUploaderTest.java
@@ -50,7 +50,7 @@ class BuildInformationUploaderTest {
 
   @Test
   public void buildInformationIsPostedToCorrectEndpointWithQueryParams()
-      throws IOException, URISyntaxException {
+      throws IOException {
     final String buildInfoLink = "/api/buildInfoLink";
     when(mockSpaceHome.getBuildInformationLink()).thenReturn(buildInfoLink);
     when(mockSpaceHomeSelector.getSpaceHome(Optional.empty())).thenReturn(mockSpaceHome);
@@ -70,10 +70,15 @@ class BuildInformationUploaderTest {
             .withVcsRoot("vcsRoot")
             .build();
 
+    final OctopusPackageVersionBuildInformationMappedResource response =
+        new OctopusPackageVersionBuildInformationMappedResource();
+    response.setId("ObjectId");
+    when(mockClient.post(any(), any(), any())).thenReturn(response);
+
     final BuildInformationUploader uploader =
         new BuildInformationUploader(mockClient, mockSpaceHomeSelector);
 
-    uploader.upload(context);
+    final String result = uploader.upload(context);
     verify(mockSpaceHomeSelector, times(1)).getSpaceHome(Optional.empty());
 
     final ArgumentCaptor<RequestEndpoint> requestEndpointCaptor =


### PR DESCRIPTION
Updates the bulidinformationcontext (and builder) to explicitly specify fields which are not _required_ are now represented using Optional - non-optional fields are deemed required.

This change also updates the BuildInformationUploader to return the ID of the item which was uploaded - thus allowing the consumer of this API to update/delete the created resource if required (rather than having to re-query for the created resource.