### PR TITLE
Replace deprecated classifier in jar tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,12 @@ subprojects {
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {
-        classifier = 'sources'
+        archiveClassifier.set('sources')
         from sourceSets.main.allSource
     }
 
     task javadocJar(type: Jar, dependsOn: javadoc) {
-        classifier = 'javadoc'
+        archiveClassifier.set('javadoc')
         from javadoc.destinationDir
     }
 


### PR DESCRIPTION
Replaced deprecated "classifier"  on gradle jar tasks with post gradle v5.1 "archiveClassifier"