### PR TITLE
Offer Api Key validation in SDK

### DIFF
--- a/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.utils;
+
+public class ApiKeyValidator {
+
+  public static void validate(String apiKeyValue) {
+    final String API_KEY_PREFIX = "API-";
+    if (!apiKeyValue.startsWith(API_KEY_PREFIX)) {
+      throw new IllegalArgumentException("APi Key must start with " + API_KEY_PREFIX);
+    }
+
+    int keyLength = apiKeyValue.length();
+    if (keyLength < 29 || keyLength > 36) {
+      throw new IllegalArgumentException("Api Key must have between 29 and 36 characters (including prefix)");
+    }
+
+    final String keyWithoutPrefix = apiKeyValue.substring(API_KEY_PREFIX.length());
+    for (char c : keyWithoutPrefix.toCharArray()) {
+      if (!Character.isDigit(c) && !Character.isUpperCase(c)) {
+        throw new IllegalArgumentException("Api key (excluding prefix) )must contains only digits and upper-case "
+            + "characters");
+      }
+    }
+  }
+}

--- a/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
@@ -17,10 +17,10 @@ package com.octopus.sdk.utils;
 
 public class ApiKeyValidator {
 
-  public static void validate(String apiKeyValue) {
+  public static void validate(final String apiKeyValue) {
     final String API_KEY_PREFIX = "API-";
     if (!apiKeyValue.startsWith(API_KEY_PREFIX)) {
-      throw new IllegalArgumentException("APi Key must start with " + API_KEY_PREFIX);
+      throw new IllegalArgumentException("API Key must start with " + API_KEY_PREFIX);
     }
 
     int keyLength = apiKeyValue.length();
@@ -33,7 +33,7 @@ public class ApiKeyValidator {
     for (char c : keyWithoutPrefix.toCharArray()) {
       if (!Character.isDigit(c) && !Character.isUpperCase(c)) {
         throw new IllegalArgumentException(
-            "Api key (excluding prefix) )must contains only digits and upper-case " + "characters");
+            "Api key (excluding prefix) )must contains only digits and upper-case characters");
       }
     }
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
@@ -26,14 +26,14 @@ public class ApiKeyValidator {
     int keyLength = apiKeyValue.length();
     if (keyLength < 29 || keyLength > 36) {
       throw new IllegalArgumentException(
-          "Api Key must have between 29 and 36 characters (including prefix)");
+          "API Key must have between 29 and 36 characters (including prefix)");
     }
 
     final String keyWithoutPrefix = apiKeyValue.substring(API_KEY_PREFIX.length());
     for (char c : keyWithoutPrefix.toCharArray()) {
       if (!Character.isDigit(c) && !Character.isUpperCase(c)) {
         throw new IllegalArgumentException(
-            "Api key (excluding prefix) )must contains only digits and upper-case characters");
+            "API key (excluding prefix) )must contains only digits and upper-case characters");
       }
     }
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/utils/ApiKeyValidator.java
@@ -25,14 +25,15 @@ public class ApiKeyValidator {
 
     int keyLength = apiKeyValue.length();
     if (keyLength < 29 || keyLength > 36) {
-      throw new IllegalArgumentException("Api Key must have between 29 and 36 characters (including prefix)");
+      throw new IllegalArgumentException(
+          "Api Key must have between 29 and 36 characters (including prefix)");
     }
 
     final String keyWithoutPrefix = apiKeyValue.substring(API_KEY_PREFIX.length());
     for (char c : keyWithoutPrefix.toCharArray()) {
       if (!Character.isDigit(c) && !Character.isUpperCase(c)) {
-        throw new IllegalArgumentException("Api key (excluding prefix) )must contains only digits and upper-case "
-            + "characters");
+        throw new IllegalArgumentException(
+            "Api key (excluding prefix) )must contains only digits and upper-case " + "characters");
       }
     }
   }

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -24,25 +24,29 @@ class ApiKeyValidatorTest {
   @Test
   public void keyNotStartingWithAPIDashFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("BLAH-1234567890ABCDEFGHIJKLMNOPQRS"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("API Key must start with API-");
   }
 
   @Test
   public void keyWhichIsTooLongFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMNOPQRSTUVW"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Api Key must have between 29 and 36 characters (including prefix)");
   }
 
   @Test
   public void keyWhichIsTooShortFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMN"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Api Key must have between 29 and 36 characters (including prefix)");
   }
 
   @Test
-  public void keyContainingNoAlphaNumericCharactersfails() {
+  public void keyContainingNoAlphaNumericCharactersFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLM-0"))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Api key (excluding prefix) )must contains only digits and upper-case characters");
   }
 
   @Test

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -32,14 +32,14 @@ class ApiKeyValidatorTest {
   public void keyWhichIsTooLongFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMNOPQRSTUVW"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Api Key must have between 29 and 36 characters (including prefix)");
+        .hasMessage("API Key must have between 29 and 36 characters (including prefix)");
   }
 
   @Test
   public void keyWhichIsTooShortFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMN"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Api Key must have between 29 and 36 characters (including prefix)");
+        .hasMessage("API Key must have between 29 and 36 characters (including prefix)");
   }
 
   @Test
@@ -47,7 +47,7 @@ class ApiKeyValidatorTest {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLM-0"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Api key (excluding prefix) )must contains only digits and upper-case characters");
+            "APIgst key (excluding prefix) )must contains only digits and upper-case characters");
   }
 
   @Test

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -40,6 +40,12 @@ class ApiKeyValidatorTest {
   }
 
   @Test
+  public void keyContainingNoAlphaNumericCharactersfails() {
+    assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLM-0"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void validKeyDoesNotThrow() {
     ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMNO");
   }

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class ApiKeyValidatorTest {
-
-
+  
   @Test
   public void keyNotStartingWithAPIDashFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("BLAH-1234567890ABCDEFGHIJKLMNOPQRS"))

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -15,12 +15,12 @@
 
 package com.octopus.sdk.utils;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import org.junit.jupiter.api.Test;
+
 class ApiKeyValidatorTest {
-  
+
   @Test
   public void keyNotStartingWithAPIDashFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("BLAH-1234567890ABCDEFGHIJKLMNOPQRS"))

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -46,7 +46,8 @@ class ApiKeyValidatorTest {
   public void keyContainingNoAlphaNumericCharactersFails() {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLM-0"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Api key (excluding prefix) )must contains only digits and upper-case characters");
+        .hasMessage(
+            "Api key (excluding prefix) )must contains only digits and upper-case characters");
   }
 
   @Test

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class ApiKeyValidatorTest {
+
+
+  @Test
+  public void keyNotStartingWithAPIDashFails() {
+    assertThatThrownBy(() -> ApiKeyValidator.validate("BLAH-1234567890ABCDEFGHIJKLMNOPQRS"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void keyWhichIsTooLongFails() {
+    assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMNOPQRSTUVW"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void keyWhichIsTooShortFails() {
+    assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMN"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void validKeyDoesNotThrow() {
+    ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLMNO");
+  }
+}

--- a/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/utils/ApiKeyValidatorTest.java
@@ -47,7 +47,7 @@ class ApiKeyValidatorTest {
     assertThatThrownBy(() -> ApiKeyValidator.validate("API-1234567890ABCDEFGHIJKLM-0"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "APIgst key (excluding prefix) )must contains only digits and upper-case characters");
+            "API key (excluding prefix) )must contains only digits and upper-case characters");
   }
 
   @Test


### PR DESCRIPTION
Octopus CI plugins are all required to validate API Keys - to ensure a consistent response to invalid keys, the validation of said key has been moved into the SDK, such that it can be reused in all plugins.