### PR TITLE
TestSupport: OctopusServer exposes port as well as url

### DIFF
--- a/test-support/src/main/java/com/octopus/testsupport/DockerisedOctopusDeployServer.java
+++ b/test-support/src/main/java/com/octopus/testsupport/DockerisedOctopusDeployServer.java
@@ -86,6 +86,9 @@ public class DockerisedOctopusDeployServer implements OctopusDeployServer {
     return apiKey;
   }
 
+  @Override
+  public int getPort() { return OCTOPUS_SERVER_DEPLOY_PORT; }
+
   public static DockerisedOctopusDeployServer createOctopusServer() throws IOException {
 
     final Network network = Network.newNetwork();

--- a/test-support/src/main/java/com/octopus/testsupport/DockerisedOctopusDeployServer.java
+++ b/test-support/src/main/java/com/octopus/testsupport/DockerisedOctopusDeployServer.java
@@ -87,7 +87,9 @@ public class DockerisedOctopusDeployServer implements OctopusDeployServer {
   }
 
   @Override
-  public int getPort() { return OCTOPUS_SERVER_DEPLOY_PORT; }
+  public int getPort() {
+    return OCTOPUS_SERVER_DEPLOY_PORT;
+  }
 
   public static DockerisedOctopusDeployServer createOctopusServer() throws IOException {
 

--- a/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
+++ b/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
@@ -29,4 +29,7 @@ public class ExistingOctopusDeployServer implements OctopusDeployServer {
 
   @Override
   public void close() {}
+
+  @Override
+  public int getPort() { return 8065; }
 }

--- a/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
+++ b/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
@@ -31,5 +31,7 @@ public class ExistingOctopusDeployServer implements OctopusDeployServer {
   public void close() {}
 
   @Override
-  public int getPort() { return 8065; }
+  public int getPort() {
+    return 8065;
+  }
 }

--- a/test-support/src/main/java/com/octopus/testsupport/OctopusDeployServer.java
+++ b/test-support/src/main/java/com/octopus/testsupport/OctopusDeployServer.java
@@ -20,4 +20,6 @@ public interface OctopusDeployServer extends AutoCloseable {
   String getOctopusUrl();
 
   String getApiKey();
+
+  int getPort();
 }


### PR DESCRIPTION
To support dockerised testing, it is useful for the test support octopus server to expose the port it has exposed, as well as the existing URL.

This way, other contains can be started, and pointed at localhost:<port> rather than attempting to connect via the docker network.