### PR TITLE
Add an appender handler

### DIFF
--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation 'com.google.code.gson:gson'
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
-  runtimeOnly 'org.apache.logging.log4j:log4j-core'
+  implementation 'org.apache.logging.log4j:log4j-core'
   testRuntimeOnly 'xerces:xercesImpl'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/octopus-sdk/src/main/java/com/octopus/sdk/logging/AppenderHandler.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/logging/AppenderHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+
+public class AppenderHandler {
+
+  private static final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+  private static final Configuration config = ctx.getConfiguration();
+
+  public static void registerLogAppender(Appender appender, Level sdkLogLevel) {
+    config.getRootLogger().addAppender(appender, sdkLogLevel, null);
+    config.getLoggerConfig("com.octopus").setLevel(sdkLogLevel);
+    ctx.updateLoggers();
+  }
+
+  public static void deregisterLogAppender(String appenderName) {
+    config.getRootLogger().removeAppender(appenderName);
+    config.getLoggerConfig("com.octopus").setLevel(Level.INFO);
+  }
+}

--- a/octopus-sdk/src/main/java/com/octopus/sdk/logging/SdkLogAppenderHelper.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/logging/SdkLogAppenderHelper.java
@@ -23,8 +23,10 @@ import org.apache.logging.log4j.core.config.Configuration;
 
 public class SdkLogAppenderHelper implements AutoCloseable {
 
-  private static final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-  private static final Configuration config = ctx.getConfiguration();
+  private static final LoggerContext CONTEXT = (LoggerContext) LogManager.getContext(false);
+  private static final Configuration LOG_CONFIG = CONTEXT.getConfiguration();
+  private static final Level INITIAL_SDK_LOG_LEVEL =
+      LOG_CONFIG.getLoggerConfig("com.octopus").getLevel();
 
   private final String appenderName;
 
@@ -35,15 +37,15 @@ public class SdkLogAppenderHelper implements AutoCloseable {
   @SuppressWarnings("unused")
   public static SdkLogAppenderHelper registerLogAppender(
       final Appender appender, final Level level) {
-    config.getRootLogger().addAppender(appender, level, null);
-    config.getLoggerConfig("com.octopus").setLevel(level);
-    ctx.updateLoggers();
+    LOG_CONFIG.getRootLogger().addAppender(appender, level, null);
+    LOG_CONFIG.getLoggerConfig("com.octopus").setLevel(level);
+    CONTEXT.updateLoggers();
     return new SdkLogAppenderHelper(appender.getName());
   }
 
   @Override
   public void close() {
-    config.getRootLogger().removeAppender(appenderName);
-    config.getLoggerConfig("com.octopus").setLevel(Level.INFO);
+    LOG_CONFIG.getRootLogger().removeAppender(appenderName);
+    LOG_CONFIG.getLoggerConfig("com.octopus").setLevel(INITIAL_SDK_LOG_LEVEL);
   }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/logging/SdkLogAppenderHelper.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/logging/SdkLogAppenderHelper.java
@@ -21,19 +21,29 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 
-public class AppenderHandler {
+public class SdkLogAppenderHelper implements AutoCloseable {
 
   private static final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
   private static final Configuration config = ctx.getConfiguration();
 
-  public static void registerLogAppender(Appender appender, Level sdkLogLevel) {
+  private final Appender appender;
+  private final Level sdkLogLevel;
+
+  public SdkLogAppenderHelper(final Appender appender, final Level level) {
+    this.appender = appender;
+    this.sdkLogLevel = level;
+  }
+
+  @SuppressWarnings("unused")
+  public void registerLogAppender() {
     config.getRootLogger().addAppender(appender, sdkLogLevel, null);
     config.getLoggerConfig("com.octopus").setLevel(sdkLogLevel);
     ctx.updateLoggers();
   }
 
-  public static void deregisterLogAppender(String appenderName) {
-    config.getRootLogger().removeAppender(appenderName);
+  @Override
+  public void close() {
+    config.getRootLogger().removeAppender(appender.getName());
     config.getLoggerConfig("com.octopus").setLevel(Level.INFO);
   }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/logging/SdkLogAppenderHelper.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/logging/SdkLogAppenderHelper.java
@@ -26,24 +26,24 @@ public class SdkLogAppenderHelper implements AutoCloseable {
   private static final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
   private static final Configuration config = ctx.getConfiguration();
 
-  private final Appender appender;
-  private final Level sdkLogLevel;
+  private final String appenderName;
 
-  public SdkLogAppenderHelper(final Appender appender, final Level level) {
-    this.appender = appender;
-    this.sdkLogLevel = level;
+  private SdkLogAppenderHelper(String appenderName) {
+    this.appenderName = appenderName;
   }
 
   @SuppressWarnings("unused")
-  public void registerLogAppender() {
-    config.getRootLogger().addAppender(appender, sdkLogLevel, null);
-    config.getLoggerConfig("com.octopus").setLevel(sdkLogLevel);
+  public static SdkLogAppenderHelper registerLogAppender(
+      final Appender appender, final Level level) {
+    config.getRootLogger().addAppender(appender, level, null);
+    config.getLoggerConfig("com.octopus").setLevel(level);
     ctx.updateLoggers();
+    return new SdkLogAppenderHelper(appender.getName());
   }
 
   @Override
   public void close() {
-    config.getRootLogger().removeAppender(appender.getName());
+    config.getRootLogger().removeAppender(appenderName);
     config.getLoggerConfig("com.octopus").setLevel(Level.INFO);
   }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operations/common/SpaceHomeSelector.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operations/common/SpaceHomeSelector.java
@@ -36,7 +36,7 @@ public class SpaceHomeSelector {
 
   public SpaceHome getSpaceHome(final Optional<String> spaceName) throws IOException {
     if (spaceName.isPresent()) {
-      LOG.debug("Accessing space '{}'", spaceName);
+      LOG.debug("Accessing space '{}'", spaceName.get());
       return spaceHomeApi.getByName(spaceName.get());
     } else {
       LOG.debug("Accessing default space");


### PR DESCRIPTION
Expose log appender handler that allows consumers of the SDK to capture SDK logging at the desired log level via a custom appender

- Methods for de/registering an appender to capture sdk logging
- Expose log4j core dependency at compile time
- Fix space logging output