### PR TITLE
TestSupport - existing OcotpusServer URL/ApiKey from Env Var

### DIFF
--- a/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
+++ b/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
@@ -19,12 +19,12 @@ public class ExistingOctopusDeployServer implements OctopusDeployServer {
 
   @Override
   public String getOctopusUrl() {
-    return "http://localhost:8065";
+    return return System.getenv("OCTOPUS_SERVER_URL");
   }
 
   @Override
   public String getApiKey() {
-    return "API-SOUCF90RQDQYWQYQ8VMVA3Y2WA41GUM";
+    return System.getenv("OCTOPUS_SERVER_API_KEY");
   }
 
   @Override

--- a/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
+++ b/test-support/src/main/java/com/octopus/testsupport/ExistingOctopusDeployServer.java
@@ -19,7 +19,7 @@ public class ExistingOctopusDeployServer implements OctopusDeployServer {
 
   @Override
   public String getOctopusUrl() {
-    return return System.getenv("OCTOPUS_SERVER_URL");
+    return System.getenv("OCTOPUS_SERVER_URL");
   }
 
   @Override


### PR DESCRIPTION
Remove hard-coded URL and API Key from the "existing Octopus Server" and replace them with environment variables (to make portable).