### PR TITLE
Fix TaskState reference in TaskResourceWithLinks

### DIFF
--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/task/TaskResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/task/TaskResource.java
@@ -15,7 +15,6 @@
 
 package com.octopus.sdk.model.task;
 
-import com.octopus.openapi.model.TaskState;
 import com.octopus.sdk.model.NamedResource;
 
 import java.time.OffsetDateTime;


### PR DESCRIPTION
The TaskResourceWithLinks contains a TaskState field, whose class was
contained within the openapi package.

This has been updated to use the class in the sdk.model package.