### PR TITLE
Create new wrapper for ExecutionCreateApi

### DIFF
--- a/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseNamedResourceApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseNamedResourceApi.java
@@ -70,4 +70,14 @@ public abstract class BaseNamedResourceApi<
           "Octopus Server reports more than 1 resource with an identical name");
     }
   }
+
+  public Optional<WRAPPED_TYPE> getByIdOrName(final String identifier) throws IOException {
+    final Optional<WRAPPED_TYPE> fromId = getById(identifier);
+
+    if (fromId.isPresent()) {
+      return fromId;
+    }
+
+    return getByName(identifier);
+  }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
@@ -64,9 +64,9 @@ public abstract class BaseResourceApi<
 
   protected Optional<RESPONSE_TYPE> getRawTypeById(final String id) throws IOException {
     Preconditions.checkNotNull(id, "Cannot provide a resource with a null id");
-    final String spacePath = String.format("%s/%s", rootPath, id);
+    final String resourcePath = String.format("%s/%s", rootPath, id);
     try {
-      final RESPONSE_TYPE overview = client.get(RequestEndpoint.fromPath(spacePath), responseType);
+      final RESPONSE_TYPE overview = client.get(RequestEndpoint.fromPath(resourcePath), responseType);
       return Optional.of(overview);
     } catch (final HttpException e) {
       LOG.error(

--- a/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
@@ -66,7 +66,8 @@ public abstract class BaseResourceApi<
     Preconditions.checkNotNull(id, "Cannot provide a resource with a null id");
     final String resourcePath = String.format("%s/%s", rootPath, id);
     try {
-      final RESPONSE_TYPE overview = client.get(RequestEndpoint.fromPath(resourcePath), responseType);
+      final RESPONSE_TYPE overview =
+          client.get(RequestEndpoint.fromPath(resourcePath), responseType);
       return Optional.of(overview);
     } catch (final HttpException e) {
       LOG.error(

--- a/octopus-sdk/src/main/java/com/octopus/sdk/domain/Space.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/domain/Space.java
@@ -29,7 +29,7 @@ import com.octopus.sdk.api.TenantApi;
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.sdk.model.space.SpaceHome;
 import com.octopus.sdk.model.space.SpaceOverviewWithLinks;
-import com.octopus.sdk.operation.ExecutionsCreateApi;
+import com.octopus.sdk.operation.executionapi.ExecutionsCreateApi;
 
 public class Space {
   private final OctopusClient client;

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
@@ -17,6 +17,8 @@ package com.octopus.sdk.model;
 
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.annotations.SerializedName;
 
 public class BaseResource {
@@ -31,8 +33,13 @@ public class BaseResource {
     return id;
   }
 
-  public Map<String, String> getLinks() {
-    return links;
+  public ImmutableMap<String, String> getLinks() {
+    return ImmutableMap.copyOf(links);
+  }
+
+  @VisibleForTesting
+  public void setLinks(final Map<String, String> links) {
+    this.links = links;
   }
 
   protected String getCleansedLink(final String linkTag) {

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/space/SpaceHome.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/space/SpaceHome.java
@@ -356,7 +356,7 @@ public class SpaceHome {
   }
 
   public String getExecutionsCreateApiReleasesCreateLink() {
-    return LinkHelpers.getCleansedRawLink(getLinks().get("ReleasesCreateApiReleaseCreate"));
+    return LinkHelpers.getCleansedRawLink(getLinks().get("ExecutionsCreateApiReleaseCreate"));
   }
 
   public String getExecutionsCreateApiRunbookRunCreateLink() {

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/BaseExecutionApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/BaseExecutionApi.java
@@ -33,7 +33,7 @@ public abstract class BaseExecutionApi<T extends CommandBody, U> {
     this.client = client;
   }
 
-  protected U execute(final T payload) throws IOException {
+  public U execute(final T payload) throws IOException {
     final SpaceOverviewApi spaceOverviewApi = SpaceOverviewApi.create(client);
     final String spaceIdentifier = payload.getSpaceIdOrName();
     Optional<SpaceOverviewWithLinks> spaceOverview =

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/BaseExecutionApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/BaseExecutionApi.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.operation.executionapi;
+
+import com.octopus.sdk.api.SpaceHomeApi;
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.model.commands.CommandBody;
+import com.octopus.sdk.model.space.SpaceHome;
+
+import java.io.IOException;
+
+public abstract class BaseExecutionApi<T extends CommandBody, U> {
+
+  protected final OctopusClient client;
+
+  public BaseExecutionApi(final OctopusClient client) {
+    this.client = client;
+  }
+
+  protected U execute(final T payload) throws IOException {
+    final SpaceHomeApi spaceHomeApi = new SpaceHomeApi(client);
+    final SpaceHome spaceHome = spaceHomeApi.getByName(payload.getSpaceIdOrName());
+    final ExecutionsCreateApi api = new ExecutionsCreateApi(client, spaceHome);
+    return sendRequest(api, payload);
+  }
+
+  protected abstract U sendRequest(final ExecutionsCreateApi api, final T payload)
+      throws IOException;
+}

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/CreateDeployment.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/CreateDeployment.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.operation.executionapi;
+
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.model.commands.CreateDeploymentCommandBody;
+
+import java.io.IOException;
+
+public class CreateDeployment extends BaseExecutionApi<CreateDeploymentCommandBody, String> {
+
+  public CreateDeployment(final OctopusClient client) {
+    super(client);
+  }
+
+  @Override
+  protected String sendRequest(
+      final ExecutionsCreateApi api, final CreateDeploymentCommandBody payload) throws IOException {
+    return api.createDeployment(payload);
+  }
+}

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/CreateRelease.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/CreateRelease.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.operation.executionapi;
+
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.model.commands.CreateReleaseCommandBody;
+
+import java.io.IOException;
+
+public class CreateRelease extends BaseExecutionApi<CreateReleaseCommandBody, String> {
+
+  public CreateRelease(final OctopusClient client) {
+    super(client);
+  }
+
+  @Override
+  protected String sendRequest(
+      final ExecutionsCreateApi api, final CreateReleaseCommandBody payload) throws IOException {
+    return api.createRelease(payload);
+  }
+}

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/ExecuteRunbook.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/ExecuteRunbook.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.operation.executionapi;
+
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.model.commands.ExecuteRunbookCommandBody;
+
+import java.io.IOException;
+
+public class ExecuteRunbook extends BaseExecutionApi<ExecuteRunbookCommandBody, String> {
+
+  public ExecuteRunbook(final OctopusClient client) {
+    super(client);
+  }
+
+  @Override
+  protected String sendRequest(
+      final ExecutionsCreateApi api, final ExecuteRunbookCommandBody payload) throws IOException {
+    return api.executeRunbook(payload);
+  }
+}

--- a/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/ExecutionsCreateApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/operation/executionapi/ExecutionsCreateApi.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.octopus.sdk.operation;
+package com.octopus.sdk.operation.executionapi;
 
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.sdk.http.RequestEndpoint;

--- a/octopus-sdk/src/test/java/com/octopus/sdk/operation/ExecutionsCreateApiTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/operation/ExecutionsCreateApiTest.java
@@ -68,13 +68,12 @@ class ExecutionsCreateApiTest {
     spaceHome = new SpaceHome(spaceHomeLinks);
     executionsCreateApi = new ExecutionsCreateApi(mockClient, spaceHome);
 
-
     // Setup a 'real' space home and overview
     final SpaceOverviewWithLinks spaceOverview = new SpaceOverviewWithLinks("TheSpace", emptySet());
     spaceOverview.setLinks(singletonMap("SpaceHome", spaceHomeLink));
 
-    when(mockClient.get(eq(RequestEndpoint.fromPath("/api/spaces/TheSpace")), any())).thenReturn(
-        spaceOverview);
+    when(mockClient.get(eq(RequestEndpoint.fromPath("/api/spaces/TheSpace")), any()))
+        .thenReturn(spaceOverview);
     when(mockClient.get(eq(RequestEndpoint.fromPath(spaceHomeLink)), any())).thenReturn(spaceHome);
 
     when(mockClient.post(any(), any(), eq(String.class))).thenReturn(responseBody);
@@ -130,7 +129,6 @@ class ExecutionsCreateApiTest {
 
   @Test
   public void createReleaseWrapperInvokesCorrectEndpointWithType() throws IOException {
-
 
     final CreateReleaseCommandBody body =
         new CreateReleaseCommandBody("TheSpace", "TheProject", "1.0.0");

--- a/octopus-sdk/src/test/java/com/octopus/sdk/operation/ExecutionsCreateApiTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/operation/ExecutionsCreateApiTest.java
@@ -29,6 +29,7 @@ import com.octopus.sdk.model.commands.CreateDeploymentCommandBody;
 import com.octopus.sdk.model.commands.CreateReleaseCommandBody;
 import com.octopus.sdk.model.commands.ExecuteRunbookCommandBody;
 import com.octopus.sdk.model.space.SpaceHome;
+import com.octopus.sdk.operation.executionapi.ExecutionsCreateApi;
 import com.octopus.sdk.support.TestHelpers;
 
 import java.io.IOException;


### PR DESCRIPTION
The concept of repostitories/spaces etc. was leaking out of the Java SDK and into the client app - in that the client app became aware of the need to traverse into the space prior to performing the operation.

New wrappers have been put around the exeuctions api whch hides this detail, which will allow clients to be simpler.