### PR TITLE
Add getters for CommandBody classes

### DIFF
--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/commands/CreateDeploymentCommandBody.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/commands/CreateDeploymentCommandBody.java
@@ -60,4 +60,20 @@ public class CreateDeploymentCommandBody extends BaseExecutionCommandBody {
   public void setUpdateVariableSnapshot(final boolean updateVariableSnapshot) {
     this.updateVariableSnapshot = updateVariableSnapshot;
   }
+
+  public String getReleaseVersion() {
+    return releaseVersion;
+  }
+
+  public String getChannelIdOrName() {
+    return channelIdOrName;
+  }
+
+  public boolean isForcePackageRedeployment() {
+    return forcePackageRedeployment;
+  }
+
+  public boolean isUpdateVariableSnapshot() {
+    return updateVariableSnapshot;
+  }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/commands/CreateReleaseCommandBody.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/commands/CreateReleaseCommandBody.java
@@ -124,4 +124,56 @@ public class CreateReleaseCommandBody extends CommandBody {
   public void setPackagePrerelease(final String packagePrerelease) {
     this.packagePrerelease = packagePrerelease;
   }
+
+  public String getProjectIdOrName() {
+    return projectIdOrName;
+  }
+
+  public String getPackageVersion() {
+    return packageVersion;
+  }
+
+  public String getGitCommit() {
+    return gitCommit;
+  }
+
+  public String getGitRef() {
+    return gitRef;
+  }
+
+  public String getReleaseVersion() {
+    return releaseVersion;
+  }
+
+  public String getChannelIdOrName() {
+    return channelIdOrName;
+  }
+
+  public List<String> getPackages() {
+    return packages;
+  }
+
+  public String getPackageFolder() {
+    return packageFolder;
+  }
+
+  public String getReleaseNotes() {
+    return releaseNotes;
+  }
+
+  public String getReleaseNotesFile() {
+    return releaseNotesFile;
+  }
+
+  public boolean isIgnoreExisting() {
+    return ignoreExisting;
+  }
+
+  public boolean isIgnoreChannelRules() {
+    return ignoreChannelRules;
+  }
+
+  public String getPackagePrerelease() {
+    return packagePrerelease;
+  }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/commands/ExecuteRunbookCommandBody.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/commands/ExecuteRunbookCommandBody.java
@@ -47,4 +47,12 @@ public class ExecuteRunbookCommandBody extends BaseExecutionCommandBody {
   public void setSnapshot(final String snapshot) {
     this.snapshot = snapshot;
   }
+
+  public String getRunbookName() {
+    return runbookName;
+  }
+
+  public String getSnapshot() {
+    return snapshot;
+  }
 }


### PR DESCRIPTION
To use the CommandBody classes in testing, the test must have access to the fields of the class.

As such, getters have been installed on all CommandBody derived classes.