### PR TITLE
Parse returned error responses

### DIFF
--- a/acceptance-tests/src/test/java/com/octopus/sdk/test/BuildInformationAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/com/octopus/sdk/test/BuildInformationAcceptanceTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.octopus.sdk.api.BuildInformationApi;
 import com.octopus.sdk.api.OverwriteMode;
-import com.octopus.sdk.http.HttpException;
+import com.octopus.sdk.exceptions.OctopusServerException;
 import com.octopus.sdk.model.buildinformation.BuildInformationResource;
 import com.octopus.sdk.model.buildinformation.OctopusPackageVersionBuildInformation;
 import com.octopus.sdk.model.buildinformation.OctopusPackageVersionBuildInformationMappedResource;
@@ -118,7 +118,7 @@ public class BuildInformationAcceptanceTest extends SpaceScopedAcceptanceTest {
     buildInfo.buildUrl("differentURL");
 
     assertThatThrownBy(() -> buildInfoApi.create(resource, OverwriteMode.FailIfExists))
-        .isInstanceOf(HttpException.class);
+        .isInstanceOf(OctopusServerException.class);
   }
 
   private BuildInformationResource createValidBuildInformation() {

--- a/acceptance-tests/src/test/java/com/octopus/sdk/test/SpacesOverviewAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/com/octopus/sdk/test/SpacesOverviewAcceptanceTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.octopus.sdk.api.SpaceOverviewApi;
 import com.octopus.sdk.api.UserApi;
-import com.octopus.sdk.http.HttpException;
+import com.octopus.sdk.exceptions.OctopusServerException;
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.sdk.model.space.SpaceOverviewResource;
 import com.octopus.sdk.model.space.SpaceOverviewWithLinks;
@@ -50,9 +50,9 @@ public class SpacesOverviewAcceptanceTest extends BaseOctopusServerEnabledTest {
     final OctopusClient client =
         new OctopusClient(httpClient, new URL(server.getOctopusUrl()), "BadKey");
     final Throwable thrown = catchThrowable(() -> SpaceOverviewApi.create(client));
-    assertThat(thrown).isInstanceOf(HttpException.class);
-    final HttpException httpException = (HttpException) thrown;
-    assertThat(httpException.getStatusCode()).isEqualTo(401);
+    assertThat(thrown).isInstanceOf(OctopusServerException.class);
+    final OctopusServerException octopusServerException = (OctopusServerException) thrown;
+    assertThat(octopusServerException.getStatusCode()).isEqualTo(401);
   }
 
   @Test
@@ -155,7 +155,7 @@ public class SpacesOverviewAcceptanceTest extends BaseOctopusServerEnabledTest {
     try {
       createdSpace.setName("");
       assertThatThrownBy(() -> spaceOverviewApi.update(createdSpace))
-          .isInstanceOf(HttpException.class);
+          .isInstanceOf(OctopusServerException.class);
     } finally {
       createdSpace.setName(spaceName);
       deleteSpaceValidly(spaceOverviewApi, createdSpace);

--- a/acceptance-tests/src/test/java/com/octopus/sdk/test/UserAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/com/octopus/sdk/test/UserAcceptanceTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.octopus.sdk.api.UserApi;
-import com.octopus.sdk.http.HttpException;
+import com.octopus.sdk.exceptions.OctopusServerException;
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.testsupport.BaseOctopusServerEnabledTest;
 
@@ -37,7 +37,7 @@ public class UserAcceptanceTest extends BaseOctopusServerEnabledTest {
     // No Api key is provided - so unable to get current user
     client = new OctopusClient(httpClient, new URL(server.getOctopusUrl()));
     final UserApi userApi = UserApi.create(client);
-    assertThatThrownBy(userApi::getCurrentUser).isInstanceOf(HttpException.class);
+    assertThatThrownBy(userApi::getCurrentUser).isInstanceOf(OctopusServerException.class);
   }
 
   @Test

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -20,6 +20,8 @@ dependencyManagement {
             entry 'error_prone_test_helpers'
         }
 
+        dependency 'com.google.api-client:google-api-client:1.32.1'
+
         dependencySet(group: 'org.apache.logging.log4j', version: '2.14.1') {
             entry 'log4j-api'
             entry 'log4j-core'

--- a/octopus-sdk/build.gradle
+++ b/octopus-sdk/build.gradle
@@ -32,8 +32,9 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.logging.log4j:log4j-core'
-  testRuntimeOnly 'xerces:xercesImpl'
+  implementation 'com.google.api-client:google-api-client'
 
+  testRuntimeOnly 'xerces:xercesImpl'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'

--- a/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
@@ -15,7 +15,7 @@
 
 package com.octopus.sdk.api;
 
-import com.octopus.sdk.exceptions.OctopusServerException;
+import com.octopus.sdk.exceptions.OctopusRequestException;
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.sdk.http.RequestEndpoint;
 import com.octopus.sdk.model.BaseResource;
@@ -69,7 +69,7 @@ public abstract class BaseResourceApi<
       final RESPONSE_TYPE overview =
           client.get(RequestEndpoint.fromPath(resourcePath), responseType);
       return Optional.of(overview);
-    } catch (final OctopusServerException e) {
+    } catch (final OctopusRequestException e) {
       LOG.error(
           "Failed to retrieve a resource with an Id of {} (http {}:{})",
           id,

--- a/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/api/BaseResourceApi.java
@@ -15,7 +15,7 @@
 
 package com.octopus.sdk.api;
 
-import com.octopus.sdk.http.HttpException;
+import com.octopus.sdk.exceptions.OctopusServerException;
 import com.octopus.sdk.http.OctopusClient;
 import com.octopus.sdk.http.RequestEndpoint;
 import com.octopus.sdk.model.BaseResource;
@@ -69,7 +69,7 @@ public abstract class BaseResourceApi<
       final RESPONSE_TYPE overview =
           client.get(RequestEndpoint.fromPath(resourcePath), responseType);
       return Optional.of(overview);
-    } catch (final HttpException e) {
+    } catch (final OctopusServerException e) {
       LOG.error(
           "Failed to retrieve a resource with an Id of {} (http {}:{})",
           id,

--- a/octopus-sdk/src/main/java/com/octopus/sdk/exceptions/OctopusRequestException.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/exceptions/OctopusRequestException.java
@@ -13,32 +13,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.octopus.sdk.model;
+package com.octopus.sdk.exceptions;
 
-import java.util.List;
+public class OctopusRequestException extends RuntimeException {
 
-import com.google.gson.annotations.SerializedName;
+  private final int statusCode;
 
-public class ErrorResponse {
-
-  @SerializedName("ErrorMessage")
-  private String errorMessage;
-
-  @SerializedName("Errors")
-  private List<String> errors;
-
-  @SerializedName("ParsedHelpLink")
-  private List<String> parsedHelpLinks;
-
-  public String getErrorMessage() {
-    return errorMessage;
+  public OctopusRequestException(final int statusCode, final String message) {
+    super(message);
+    this.statusCode = statusCode;
   }
 
-  public List<String> getErrors() {
-    return errors;
+  protected OctopusRequestException(final int statusCode) {
+    super();
+    this.statusCode = statusCode;
   }
 
-  public List<String> getParsedHelpLinks() {
-    return parsedHelpLinks;
+  public int getStatusCode() {
+    return statusCode;
   }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/exceptions/OctopusServerException.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/exceptions/OctopusServerException.java
@@ -13,18 +13,28 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.octopus.sdk.http;
+package com.octopus.sdk.exceptions;
 
-public class HttpException extends RuntimeException {
+import com.octopus.sdk.model.ErrorResponse;
 
-  private final int statusCode;
+public class OctopusServerException extends OctopusRequestException {
+  private final ErrorResponse errorResponse;
 
-  public HttpException(final int statusCode, final String message) {
-    super(message);
-    this.statusCode = statusCode;
+  public OctopusServerException(final int statusCode, final ErrorResponse errorResponse) {
+    super(statusCode);
+    this.errorResponse = errorResponse;
   }
 
-  public int getStatusCode() {
-    return statusCode;
+  @Override
+  public String getMessage() {
+    if (errorResponse.getErrors().isEmpty()) {
+      return errorResponse.getErrorMessage();
+    } else {
+      return String.join("\n", errorResponse.getErrors());
+    }
+  }
+
+  public ErrorResponse getErrorResponse() {
+    return errorResponse;
   }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
@@ -250,6 +250,8 @@ public class OctopusClient {
   private OctopusRequestException constructException(final int code, final String responseBody) {
     switch (code) {
       case HttpStatusCodes.STATUS_CODE_BAD_REQUEST:
+      case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
+      case HttpStatusCodes.STATUS_CODE_CONFLICT:
         final ErrorResponse errorResponse = gson.fromJson(responseBody, ErrorResponse.class);
         return new OctopusServerException(code, errorResponse);
       default:

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/ErrorResponse.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/ErrorResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.octopus.sdk.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class ErrorResponse {
+
+  @SerializedName("ErrorMessage")
+  private String errorMessage;
+
+  @SerializedName("Errors")
+  private List<String> errors;
+
+  @SerializedName("ParsedHelpLink")
+  private List<String> parsedHelpLinks;
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public List<String> getErrors() {
+    return errors;
+  }
+
+  public List<String> getParsedHelpLinks() {
+    return parsedHelpLinks;
+  }
+}

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/ErrorResponse.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/ErrorResponse.java
@@ -15,20 +15,22 @@
 
 package com.octopus.sdk.model;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 
+@SuppressWarnings("FieldCanBeFinal")
 public class ErrorResponse {
 
   @SerializedName("ErrorMessage")
   private String errorMessage;
 
   @SerializedName("Errors")
-  private List<String> errors;
+  private List<String> errors = Collections.emptyList();
 
   @SerializedName("ParsedHelpLink")
-  private List<String> parsedHelpLinks;
+  private List<String> parsedHelpLinks = Collections.emptyList();
 
   public String getErrorMessage() {
     return errorMessage;

--- a/octopus-sdk/src/test/java/com/octopus/sdk/http/OctopusClientTest.java
+++ b/octopus-sdk/src/test/java/com/octopus/sdk/http/OctopusClientTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import com.octopus.sdk.exceptions.OctopusRequestException;
 import com.octopus.sdk.support.HttpMessageBodyObject;
 
 import java.io.IOException;
@@ -85,10 +86,11 @@ class OctopusClientTest {
     final OctopusClient client = createClientSendingToMockServer();
     final Throwable thrown =
         catchThrowable(() -> client.get(RequestEndpoint.fromPath(PATH), Integer.class));
-    assertThat(thrown).isInstanceOf(HttpException.class);
+    assertThat(thrown).isInstanceOf(OctopusRequestException.class);
 
-    final HttpException httpException = (HttpException) thrown;
-    assertThat(httpException.getStatusCode()).isEqualTo(404);
+    final OctopusRequestException octopusRequestException = (OctopusRequestException) thrown;
+    assertThat(octopusRequestException.getStatusCode()).isEqualTo(404);
+    assertThat(octopusRequestException.getMessage()).isEqualTo("Resource not available");
   }
 
   @Test


### PR DESCRIPTION
When the OctopusServer does not respond with a "200" response, the whole response body is packaged up into a HttpException, and thrown.

However, the error response is a recognised shape, and can be decoded and passed up as clean strings.