### PR TITLE
Handle no-body error response

### DIFF
--- a/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
@@ -187,7 +187,7 @@ public class OctopusClient {
           throw e;
         }
       } else {
-        final String errorString = !responseBody.isEmpty() ? responseBody : response.message();
+        final String errorString = responseBody.isEmpty() ? response.message(): responseBody;
         throw constructException(response.code(), errorString);
       }
     } catch (final UnknownHostException e) {

--- a/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
@@ -187,7 +187,8 @@ public class OctopusClient {
           throw e;
         }
       } else {
-        throw constructException(response.code(), responseBody);
+        final String errorString = !responseBody.isEmpty() ? responseBody : response.message();
+        throw constructException(response.code(), errorString);
       }
     } catch (final UnknownHostException e) {
       LOG.error("Failed to connect to Octopus Server at {}", call.request().url());

--- a/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/http/OctopusClient.java
@@ -187,7 +187,7 @@ public class OctopusClient {
           throw e;
         }
       } else {
-        final String errorString = responseBody.isEmpty() ? response.message(): responseBody;
+        final String errorString = responseBody.isEmpty() ? response.message() : responseBody;
         throw constructException(response.code(), errorString);
       }
     } catch (final UnknownHostException e) {


### PR DESCRIPTION
If no response body exists on a non-200 response, the message of the response is used in the generated exception.