### PR TITLE
Add parent params to Resource equals/hashcode/toString

### DIFF
--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/BaseResource.java
@@ -34,6 +34,9 @@ public class BaseResource {
   }
 
   public ImmutableMap<String, String> getLinks() {
+    if (links == null) {
+      return ImmutableMap.of();
+    }
     return ImmutableMap.copyOf(links);
   }
 

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/apikey/ApiKeyResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/apikey/ApiKeyResource.java
@@ -160,12 +160,23 @@ public class ApiKeyResource extends BaseResource {
         && Objects.equals(this.lastModifiedBy, apiKeyResource.lastModifiedBy)
         && Objects.equals(this.lastModifiedOn, apiKeyResource.lastModifiedOn)
         && Objects.equals(this.purpose, apiKeyResource.purpose)
-        && Objects.equals(this.userId, apiKeyResource.userId);
+        && Objects.equals(this.userId, apiKeyResource.userId)
+        && Objects.equals(this.getId(), apiKeyResource.getId())
+        && Objects.equals(this.getLinks(), apiKeyResource.getLinks());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(apiKey, created, expires, lastModifiedBy, lastModifiedOn, purpose, userId);
+    return Objects.hash(
+        apiKey,
+        created,
+        expires,
+        lastModifiedBy,
+        lastModifiedOn,
+        purpose,
+        userId,
+        getId(),
+        getLinks());
   }
 
   @Override
@@ -179,6 +190,8 @@ public class ApiKeyResource extends BaseResource {
     sb.append("    lastModifiedOn: ").append(toIndentedString(lastModifiedOn)).append("\n");
     sb.append("    purpose: ").append(toIndentedString(purpose)).append("\n");
     sb.append("    userId: ").append(toIndentedString(userId)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/buildinformation/BuildInformationResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/buildinformation/BuildInformationResource.java
@@ -324,7 +324,9 @@ public class BuildInformationResource extends BaseResource {
         && Objects.equals(this.vcsCommitUrl, buildInformationResource.vcsCommitUrl)
         && Objects.equals(this.vcsRoot, buildInformationResource.vcsRoot)
         && Objects.equals(this.vcsType, buildInformationResource.vcsType)
-        && Objects.equals(this.workItems, buildInformationResource.workItems);
+        && Objects.equals(this.workItems, buildInformationResource.workItems)
+        && Objects.equals(this.getId(), buildInformationResource.getId())
+        && Objects.equals(this.getLinks(), buildInformationResource.getLinks());
   }
 
   @Override
@@ -344,7 +346,9 @@ public class BuildInformationResource extends BaseResource {
         vcsCommitUrl,
         vcsRoot,
         vcsType,
-        workItems);
+        workItems,
+        getId(),
+        getLinks());
   }
 
   @Override
@@ -368,6 +372,8 @@ public class BuildInformationResource extends BaseResource {
     sb.append("    vcsRoot: ").append(toIndentedString(vcsRoot)).append("\n");
     sb.append("    vcsType: ").append(toIndentedString(vcsType)).append("\n");
     sb.append("    workItems: ").append(toIndentedString(workItems)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/buildinformation/OctopusPackageVersionBuildInformationMappedResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/buildinformation/OctopusPackageVersionBuildInformationMappedResource.java
@@ -384,7 +384,10 @@ public class OctopusPackageVersionBuildInformationMappedResource extends BaseRes
         && Objects.equals(this.vcsType, octopusPackageVersionBuildInformationMappedResource.vcsType)
         && Objects.equals(this.version, octopusPackageVersionBuildInformationMappedResource.version)
         && Objects.equals(
-            this.workItems, octopusPackageVersionBuildInformationMappedResource.workItems);
+            this.workItems, octopusPackageVersionBuildInformationMappedResource.workItems)
+        && Objects.equals(this.getId(), octopusPackageVersionBuildInformationMappedResource.getId())
+        && Objects.equals(
+            this.getLinks(), octopusPackageVersionBuildInformationMappedResource.getLinks());
   }
 
   @Override
@@ -406,7 +409,9 @@ public class OctopusPackageVersionBuildInformationMappedResource extends BaseRes
         vcsRoot,
         vcsType,
         version,
-        workItems);
+        workItems,
+        getId(),
+        getLinks());
   }
 
   @Override
@@ -432,6 +437,8 @@ public class OctopusPackageVersionBuildInformationMappedResource extends BaseRes
     sb.append("    vcsType: ").append(toIndentedString(vcsType)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    workItems: ").append(toIndentedString(workItems)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/channel/ChannelResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/channel/ChannelResource.java
@@ -204,7 +204,11 @@ public class ChannelResource extends NamedResource {
         && Objects.equals(this.projectId, channelResource.projectId)
         && Objects.equals(this.rules, channelResource.rules)
         && Objects.equals(this.spaceId, channelResource.spaceId)
-        && Objects.equals(this.tenantTags, channelResource.tenantTags);
+        && Objects.equals(this.tenantTags, channelResource.tenantTags)
+        && Objects.equals(this.getId(), channelResource.getId())
+        && Objects.equals(this.getName(), channelResource.getName())
+        && Objects.equals(this.getLinks(), channelResource.getLinks())
+        && Objects.equals(this.getDescription(), channelResource.getDescription());
   }
 
   @Override
@@ -217,7 +221,11 @@ public class ChannelResource extends NamedResource {
         projectId,
         rules,
         spaceId,
-        tenantTags);
+        tenantTags,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -232,6 +240,10 @@ public class ChannelResource extends NamedResource {
     sb.append("    rules: ").append(toIndentedString(rules)).append("\n");
     sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
     sb.append("    tenantTags: ").append(toIndentedString(tenantTags)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/deployment/DeploymentResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/deployment/DeploymentResource.java
@@ -617,7 +617,11 @@ public class DeploymentResource extends NamedResource {
         && Objects.equals(this.taskId, deploymentResource.taskId)
         && Objects.equals(this.tenantId, deploymentResource.tenantId)
         && Objects.equals(this.tentacleRetentionPeriod, deploymentResource.tentacleRetentionPeriod)
-        && Objects.equals(this.useGuidedFailure, deploymentResource.useGuidedFailure);
+        && Objects.equals(this.useGuidedFailure, deploymentResource.useGuidedFailure)
+        && Objects.equals(this.getId(), deploymentResource.getId())
+        && Objects.equals(this.getName(), deploymentResource.getName())
+        && Objects.equals(this.getLinks(), deploymentResource.getLinks())
+        && Objects.equals(this.getDescription(), deploymentResource.getDescription());
   }
 
   @Override
@@ -651,7 +655,11 @@ public class DeploymentResource extends NamedResource {
         taskId,
         tenantId,
         tentacleRetentionPeriod,
-        useGuidedFailure);
+        useGuidedFailure,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -699,6 +707,10 @@ public class DeploymentResource extends NamedResource {
         .append(toIndentedString(tentacleRetentionPeriod))
         .append("\n");
     sb.append("    useGuidedFailure: ").append(toIndentedString(useGuidedFailure)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/environment/EnvironmentResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/environment/EnvironmentResource.java
@@ -156,7 +156,11 @@ public class EnvironmentResource extends NamedResource {
         && Objects.equals(this.lastModifiedOn, environmentResource.lastModifiedOn)
         && Objects.equals(this.sortOrder, environmentResource.sortOrder)
         && Objects.equals(this.spaceId, environmentResource.spaceId)
-        && Objects.equals(this.useGuidedFailure, environmentResource.useGuidedFailure);
+        && Objects.equals(this.useGuidedFailure, environmentResource.useGuidedFailure)
+        && Objects.equals(this.getId(), environmentResource.getId())
+        && Objects.equals(this.getName(), environmentResource.getName())
+        && Objects.equals(this.getLinks(), environmentResource.getLinks())
+        && Objects.equals(this.getDescription(), environmentResource.getDescription());
   }
 
   @Override
@@ -168,7 +172,11 @@ public class EnvironmentResource extends NamedResource {
         lastModifiedOn,
         sortOrder,
         spaceId,
-        useGuidedFailure);
+        useGuidedFailure,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -184,6 +192,10 @@ public class EnvironmentResource extends NamedResource {
     sb.append("    sortOrder: ").append(toIndentedString(sortOrder)).append("\n");
     sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
     sb.append("    useGuidedFailure: ").append(toIndentedString(useGuidedFailure)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/lifecycle/LifecycleResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/lifecycle/LifecycleResource.java
@@ -137,7 +137,11 @@ public class LifecycleResource extends NamedResource {
         && Objects.equals(this.phases, lifecycleResource.phases)
         && Objects.equals(this.releaseRetentionPolicy, lifecycleResource.releaseRetentionPolicy)
         && Objects.equals(this.spaceId, lifecycleResource.spaceId)
-        && Objects.equals(this.tentacleRetentionPolicy, lifecycleResource.tentacleRetentionPolicy);
+        && Objects.equals(this.tentacleRetentionPolicy, lifecycleResource.tentacleRetentionPolicy)
+        && Objects.equals(this.getId(), lifecycleResource.getId())
+        && Objects.equals(this.getName(), lifecycleResource.getName())
+        && Objects.equals(this.getLinks(), lifecycleResource.getLinks())
+        && Objects.equals(this.getDescription(), lifecycleResource.getDescription());
   }
 
   @Override
@@ -148,7 +152,11 @@ public class LifecycleResource extends NamedResource {
         phases,
         releaseRetentionPolicy,
         spaceId,
-        tentacleRetentionPolicy);
+        tentacleRetentionPolicy,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -165,6 +173,10 @@ public class LifecycleResource extends NamedResource {
     sb.append("    tentacleRetentionPolicy: ")
         .append(toIndentedString(tentacleRetentionPolicy))
         .append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/packages/PackageResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/packages/PackageResource.java
@@ -289,7 +289,9 @@ public class PackageResource extends BaseResource {
         && Objects.equals(this.releaseNotes, packageResource.releaseNotes)
         && Objects.equals(this.summary, packageResource.summary)
         && Objects.equals(this.title, packageResource.title)
-        && Objects.equals(this.version, packageResource.version);
+        && Objects.equals(this.version, packageResource.version)
+        && Objects.equals(this.getId(), packageResource.getId())
+        && Objects.equals(this.getLinks(), packageResource.getLinks());
   }
 
   @Override

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/project/ProjectResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/project/ProjectResource.java
@@ -28,6 +28,7 @@ import com.octopus.sdk.model.NamedResource;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.gson.annotations.SerializedName;
@@ -328,5 +329,160 @@ public class ProjectResource extends NamedResource {
 
   public VersioningStrategyResource getVersioningStrategy() {
     return versioningStrategy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProjectResource projectResource = (ProjectResource) o;
+    return Objects.equals(this.autoCreateRelease, projectResource.autoCreateRelease)
+        && Objects.equals(
+            this.autoDeployReleaseOverrides, projectResource.autoDeployReleaseOverrides)
+        && Objects.equals(this.clonedFromProjectId, projectResource.clonedFromProjectId)
+        && Objects.equals(this.defaultGuidedFailureMode, projectResource.defaultGuidedFailureMode)
+        && Objects.equals(
+            this.defaultToSkipIfAlreadyInstalled, projectResource.defaultToSkipIfAlreadyInstalled)
+        && Objects.equals(this.deploymentChangesTemplate, projectResource.deploymentChangesTemplate)
+        && Objects.equals(this.deploymentProcessId, projectResource.deploymentProcessId)
+        && Objects.equals(this.getDescription(), projectResource.getDescription())
+        && Objects.equals(this.discreteChannelRelease, projectResource.discreteChannelRelease)
+        && Objects.equals(this.extensionSettings, projectResource.extensionSettings)
+        && Objects.equals(this.getId(), projectResource.getId())
+        && Objects.equals(
+            this.includedLibraryVariableSetIds, projectResource.includedLibraryVariableSetIds)
+        && Objects.equals(this.isDisabled, projectResource.isDisabled)
+        && Objects.equals(this.isVersionControlled, projectResource.isVersionControlled)
+        && Objects.equals(this.lastModifiedBy, projectResource.lastModifiedBy)
+        && Objects.equals(this.lastModifiedOn, projectResource.lastModifiedOn)
+        && Objects.equals(this.lifecycleId, projectResource.lifecycleId)
+        && Objects.equals(this.getLinks(), projectResource.getLinks())
+        && Objects.equals(this.getName(), projectResource.getName())
+        && Objects.equals(this.persistenceSettings, projectResource.persistenceSettings)
+        && Objects.equals(this.projectConnectivityPolicy, projectResource.projectConnectivityPolicy)
+        && Objects.equals(this.projectGroupId, projectResource.projectGroupId)
+        && Objects.equals(this.releaseCreationStrategy, projectResource.releaseCreationStrategy)
+        && Objects.equals(this.releaseNotesTemplate, projectResource.releaseNotesTemplate)
+        && Objects.equals(this.slug, projectResource.slug)
+        && Objects.equals(this.spaceId, projectResource.spaceId)
+        && Objects.equals(this.templates, projectResource.templates)
+        && Objects.equals(this.tenantedDeploymentMode, projectResource.tenantedDeploymentMode)
+        && Objects.equals(this.variableSetId, projectResource.variableSetId)
+        && Objects.equals(this.versioningStrategy, projectResource.versioningStrategy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        autoCreateRelease,
+        autoDeployReleaseOverrides,
+        clonedFromProjectId,
+        defaultGuidedFailureMode,
+        defaultToSkipIfAlreadyInstalled,
+        deploymentChangesTemplate,
+        deploymentProcessId,
+        getDescription(),
+        discreteChannelRelease,
+        extensionSettings,
+        getId(),
+        includedLibraryVariableSetIds,
+        isDisabled,
+        isVersionControlled,
+        lastModifiedBy,
+        lastModifiedOn,
+        lifecycleId,
+        getLinks(),
+        getName(),
+        persistenceSettings,
+        projectConnectivityPolicy,
+        projectGroupId,
+        releaseCreationStrategy,
+        releaseNotesTemplate,
+        slug,
+        spaceId,
+        templates,
+        tenantedDeploymentMode,
+        variableSetId,
+        versioningStrategy);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ProjectResource {\n");
+    sb.append("    autoCreateRelease: ").append(toIndentedString(autoCreateRelease)).append("\n");
+    sb.append("    autoDeployReleaseOverrides: ")
+        .append(toIndentedString(autoDeployReleaseOverrides))
+        .append("\n");
+    sb.append("    clonedFromProjectId: ")
+        .append(toIndentedString(clonedFromProjectId))
+        .append("\n");
+    sb.append("    defaultGuidedFailureMode: ")
+        .append(toIndentedString(defaultGuidedFailureMode))
+        .append("\n");
+    sb.append("    defaultToSkipIfAlreadyInstalled: ")
+        .append(toIndentedString(defaultToSkipIfAlreadyInstalled))
+        .append("\n");
+    sb.append("    deploymentChangesTemplate: ")
+        .append(toIndentedString(deploymentChangesTemplate))
+        .append("\n");
+    sb.append("    deploymentProcessId: ")
+        .append(toIndentedString(deploymentProcessId))
+        .append("\n");
+    sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
+    sb.append("    discreteChannelRelease: ")
+        .append(toIndentedString(discreteChannelRelease))
+        .append("\n");
+    sb.append("    extensionSettings: ").append(toIndentedString(extensionSettings)).append("\n");
+    sb.append("    id: ").append(toIndentedString(getId())).append("\n");
+    sb.append("    includedLibraryVariableSetIds: ")
+        .append(toIndentedString(includedLibraryVariableSetIds))
+        .append("\n");
+    sb.append("    isDisabled: ").append(toIndentedString(isDisabled)).append("\n");
+    sb.append("    isVersionControlled: ")
+        .append(toIndentedString(isVersionControlled))
+        .append("\n");
+    sb.append("    lastModifiedBy: ").append(toIndentedString(lastModifiedBy)).append("\n");
+    sb.append("    lastModifiedOn: ").append(toIndentedString(lastModifiedOn)).append("\n");
+    sb.append("    lifecycleId: ").append(toIndentedString(lifecycleId)).append("\n");
+    sb.append("    links: ").append(toIndentedString(getLinks())).append("\n");
+    sb.append("    name: ").append(toIndentedString(getName())).append("\n");
+    sb.append("    persistenceSettings: ")
+        .append(toIndentedString(persistenceSettings))
+        .append("\n");
+    sb.append("    projectConnectivityPolicy: ")
+        .append(toIndentedString(projectConnectivityPolicy))
+        .append("\n");
+    sb.append("    projectGroupId: ").append(toIndentedString(projectGroupId)).append("\n");
+    sb.append("    releaseCreationStrategy: ")
+        .append(toIndentedString(releaseCreationStrategy))
+        .append("\n");
+    sb.append("    releaseNotesTemplate: ")
+        .append(toIndentedString(releaseNotesTemplate))
+        .append("\n");
+    sb.append("    slug: ").append(toIndentedString(slug)).append("\n");
+    sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
+    sb.append("    templates: ").append(toIndentedString(templates)).append("\n");
+    sb.append("    tenantedDeploymentMode: ")
+        .append(toIndentedString(tenantedDeploymentMode))
+        .append("\n");
+    sb.append("    variableSetId: ").append(toIndentedString(variableSetId)).append("\n");
+    sb.append("    versioningStrategy: ").append(toIndentedString(versioningStrategy)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
   }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/projectgroup/ProjectGroupResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/projectgroup/ProjectGroupResource.java
@@ -137,12 +137,25 @@ public class ProjectGroupResource extends NamedResource {
         && Objects.equals(this.lastModifiedBy, projectGroupResource.lastModifiedBy)
         && Objects.equals(this.lastModifiedOn, projectGroupResource.lastModifiedOn)
         && Objects.equals(this.retentionPolicyId, projectGroupResource.retentionPolicyId)
-        && Objects.equals(this.spaceId, projectGroupResource.spaceId);
+        && Objects.equals(this.spaceId, projectGroupResource.spaceId)
+        && Objects.equals(this.getId(), projectGroupResource.getId())
+        && Objects.equals(this.getName(), projectGroupResource.getName())
+        && Objects.equals(this.getLinks(), projectGroupResource.getLinks())
+        && Objects.equals(this.getDescription(), projectGroupResource.getDescription());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(environmentIds, lastModifiedBy, lastModifiedOn, retentionPolicyId, spaceId);
+    return Objects.hash(
+        environmentIds,
+        lastModifiedBy,
+        lastModifiedOn,
+        retentionPolicyId,
+        spaceId,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -154,6 +167,10 @@ public class ProjectGroupResource extends NamedResource {
     sb.append("    lastModifiedOn: ").append(toIndentedString(lastModifiedOn)).append("\n");
     sb.append("    retentionPolicyId: ").append(toIndentedString(retentionPolicyId)).append("\n");
     sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/release/ReleaseResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/release/ReleaseResource.java
@@ -346,7 +346,9 @@ public class ReleaseResource extends BaseResource {
         && Objects.equals(this.selectedPackages, releaseResource.selectedPackages)
         && Objects.equals(this.spaceId, releaseResource.spaceId)
         && Objects.equals(this.version, releaseResource.version)
-        && Objects.equals(this.versionControlReference, releaseResource.versionControlReference);
+        && Objects.equals(this.versionControlReference, releaseResource.versionControlReference)
+        && Objects.equals(this.getId(), releaseResource.getId())
+        && Objects.equals(this.getLinks(), releaseResource.getLinks());
   }
 
   @Override
@@ -366,7 +368,9 @@ public class ReleaseResource extends BaseResource {
         selectedPackages,
         spaceId,
         version,
-        versionControlReference);
+        versionControlReference,
+        getId(),
+        getLinks());
   }
 
   @Override
@@ -396,6 +400,8 @@ public class ReleaseResource extends BaseResource {
     sb.append("    versionControlReference: ")
         .append(toIndentedString(versionControlReference))
         .append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/runbook/RunbookResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/runbook/RunbookResource.java
@@ -250,7 +250,11 @@ public class RunbookResource extends NamedResource {
             this.publishedRunbookSnapshotId, runbookResource.publishedRunbookSnapshotId)
         && Objects.equals(this.runbookProcessId, runbookResource.runbookProcessId)
         && Objects.equals(this.runRetentionPolicy, runbookResource.runRetentionPolicy)
-        && Objects.equals(this.spaceId, runbookResource.spaceId);
+        && Objects.equals(this.spaceId, runbookResource.spaceId)
+        && Objects.equals(this.getId(), runbookResource.getId())
+        && Objects.equals(this.getName(), runbookResource.getName())
+        && Objects.equals(this.getLinks(), runbookResource.getLinks())
+        && Objects.equals(this.getDescription(), runbookResource.getDescription());
   }
 
   @Override
@@ -267,7 +271,11 @@ public class RunbookResource extends NamedResource {
         publishedRunbookSnapshotId,
         runbookProcessId,
         runRetentionPolicy,
-        spaceId);
+        spaceId,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -290,6 +298,10 @@ public class RunbookResource extends NamedResource {
     sb.append("    runbookProcessId: ").append(toIndentedString(runbookProcessId)).append("\n");
     sb.append("    runRetentionPolicy: ").append(toIndentedString(runRetentionPolicy)).append("\n");
     sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/runbook/RunbookRunResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/runbook/RunbookRunResource.java
@@ -550,7 +550,11 @@ public class RunbookRunResource extends NamedResource {
         && Objects.equals(this.taskId, runbookRunResource.taskId)
         && Objects.equals(this.tenantId, runbookRunResource.tenantId)
         && Objects.equals(this.tentacleRetentionPeriod, runbookRunResource.tentacleRetentionPeriod)
-        && Objects.equals(this.useGuidedFailure, runbookRunResource.useGuidedFailure);
+        && Objects.equals(this.useGuidedFailure, runbookRunResource.useGuidedFailure)
+        && Objects.equals(this.getId(), runbookRunResource.getId())
+        && Objects.equals(this.getName(), runbookRunResource.getName())
+        && Objects.equals(this.getLinks(), runbookRunResource.getLinks())
+        && Objects.equals(this.getDescription(), runbookRunResource.getDescription());
   }
 
   @Override
@@ -581,7 +585,11 @@ public class RunbookRunResource extends NamedResource {
         taskId,
         tenantId,
         tentacleRetentionPeriod,
-        useGuidedFailure);
+        useGuidedFailure,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -624,6 +632,10 @@ public class RunbookRunResource extends NamedResource {
         .append(toIndentedString(tentacleRetentionPeriod))
         .append("\n");
     sb.append("    useGuidedFailure: ").append(toIndentedString(useGuidedFailure)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/space/SpaceOverviewResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/space/SpaceOverviewResource.java
@@ -18,6 +18,7 @@ package com.octopus.sdk.model.space;
 import com.octopus.sdk.model.NamedResource;
 
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.gson.annotations.SerializedName;
@@ -93,5 +94,72 @@ public class SpaceOverviewResource extends NamedResource {
 
   public void setTaskQueueStopped(final Boolean taskQueueStopped) {
     this.taskQueueStopped = taskQueueStopped;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SpaceOverviewResource spaceOverviewResource = (SpaceOverviewResource) o;
+    return Objects.equals(this.getDescription(), spaceOverviewResource.getDescription())
+        && Objects.equals(this.getId(), spaceOverviewResource.getId())
+        && Objects.equals(this.isDefault, spaceOverviewResource.isDefault)
+        && Objects.equals(this.lastModifiedBy, spaceOverviewResource.lastModifiedBy)
+        && Objects.equals(this.lastModifiedOn, spaceOverviewResource.lastModifiedOn)
+        && Objects.equals(this.getLinks(), spaceOverviewResource.getLinks())
+        && Objects.equals(this.getName(), spaceOverviewResource.getName())
+        && Objects.equals(
+            this.spaceManagersTeamMembers, spaceOverviewResource.spaceManagersTeamMembers)
+        && Objects.equals(this.spaceManagersTeams, spaceOverviewResource.spaceManagersTeams)
+        && Objects.equals(this.taskQueueStopped, spaceOverviewResource.taskQueueStopped);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getDescription(),
+        getId(),
+        isDefault,
+        lastModifiedBy,
+        lastModifiedOn,
+        getLinks(),
+        getName(),
+        spaceManagersTeamMembers,
+        spaceManagersTeams,
+        taskQueueStopped);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SpaceResource {\n");
+    sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
+    sb.append("    id: ").append(toIndentedString(getId())).append("\n");
+    sb.append("    isDefault: ").append(toIndentedString(isDefault)).append("\n");
+    sb.append("    lastModifiedBy: ").append(toIndentedString(lastModifiedBy)).append("\n");
+    sb.append("    lastModifiedOn: ").append(toIndentedString(lastModifiedOn)).append("\n");
+    sb.append("    links: ").append(toIndentedString(getLinks())).append("\n");
+    sb.append("    name: ").append(toIndentedString(getName())).append("\n");
+    sb.append("    spaceManagersTeamMembers: ")
+        .append(toIndentedString(spaceManagersTeamMembers))
+        .append("\n");
+    sb.append("    spaceManagersTeams: ").append(toIndentedString(spaceManagersTeams)).append("\n");
+    sb.append("    taskQueueStopped: ").append(toIndentedString(taskQueueStopped)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
   }
 }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/tag/TagResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/tag/TagResource.java
@@ -90,12 +90,17 @@ public class TagResource extends NamedResource {
     TagResource tagResource = (TagResource) o;
     return Objects.equals(this.canonicalTagName, tagResource.canonicalTagName)
         && Objects.equals(this.color, tagResource.color)
-        && Objects.equals(this.sortOrder, tagResource.sortOrder);
+        && Objects.equals(this.sortOrder, tagResource.sortOrder)
+        && Objects.equals(this.getId(), tagResource.getId())
+        && Objects.equals(this.getName(), tagResource.getName())
+        && Objects.equals(this.getLinks(), tagResource.getLinks())
+        && Objects.equals(this.getDescription(), tagResource.getDescription());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(canonicalTagName, color, sortOrder);
+    return Objects.hash(
+        canonicalTagName, color, sortOrder, getId(), getName(), getDescription(), getLinks());
   }
 
   @Override
@@ -105,6 +110,10 @@ public class TagResource extends NamedResource {
     sb.append("    canonicalTagName: ").append(toIndentedString(canonicalTagName)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("    sortOrder: ").append(toIndentedString(sortOrder)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/tagset/TagSetResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/tagset/TagSetResource.java
@@ -137,12 +137,25 @@ public class TagSetResource extends NamedResource {
         && Objects.equals(this.lastModifiedOn, tagSetResource.lastModifiedOn)
         && Objects.equals(this.sortOrder, tagSetResource.sortOrder)
         && Objects.equals(this.spaceId, tagSetResource.spaceId)
-        && Objects.equals(this.tags, tagSetResource.tags);
+        && Objects.equals(this.tags, tagSetResource.tags)
+        && Objects.equals(this.getId(), tagSetResource.getId())
+        && Objects.equals(this.getName(), tagSetResource.getName())
+        && Objects.equals(this.getLinks(), tagSetResource.getLinks())
+        && Objects.equals(this.getDescription(), tagSetResource.getDescription());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(lastModifiedBy, lastModifiedOn, sortOrder, spaceId, tags);
+    return Objects.hash(
+        lastModifiedBy,
+        lastModifiedOn,
+        sortOrder,
+        spaceId,
+        tags,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -154,6 +167,10 @@ public class TagSetResource extends NamedResource {
     sb.append("    sortOrder: ").append(toIndentedString(sortOrder)).append("\n");
     sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/task/TaskResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/task/TaskResource.java
@@ -388,7 +388,11 @@ public class TaskResource extends NamedResource {
         && Objects.equals(this.serverNode, taskResource.serverNode)
         && Objects.equals(this.spaceId, taskResource.spaceId)
         && Objects.equals(this.startTime, taskResource.startTime)
-        && Objects.equals(this.state, taskResource.state);
+        && Objects.equals(this.state, taskResource.state)
+        && Objects.equals(this.getId(), taskResource.getId())
+        && Objects.equals(this.getName(), taskResource.getName())
+        && Objects.equals(this.getLinks(), taskResource.getLinks())
+        && Objects.equals(this.getDescription(), taskResource.getDescription());
   }
 
   @Override
@@ -413,7 +417,11 @@ public class TaskResource extends NamedResource {
         serverNode,
         spaceId,
         startTime,
-        state);
+        state,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -448,6 +456,10 @@ public class TaskResource extends NamedResource {
     sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
     sb.append("    startTime: ").append(toIndentedString(startTime)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/tenant/TenantResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/tenant/TenantResource.java
@@ -165,7 +165,11 @@ public class TenantResource extends NamedResource {
         && Objects.equals(this.lastModifiedOn, tenantResource.lastModifiedOn)
         && Objects.equals(this.projectEnvironments, tenantResource.projectEnvironments)
         && Objects.equals(this.spaceId, tenantResource.spaceId)
-        && Objects.equals(this.tenantTags, tenantResource.tenantTags);
+        && Objects.equals(this.tenantTags, tenantResource.tenantTags)
+        && Objects.equals(this.getId(), tenantResource.getId())
+        && Objects.equals(this.getName(), tenantResource.getName())
+        && Objects.equals(this.getLinks(), tenantResource.getLinks())
+        && Objects.equals(this.getDescription(), tenantResource.getDescription());
   }
 
   @Override
@@ -176,7 +180,11 @@ public class TenantResource extends NamedResource {
         lastModifiedOn,
         projectEnvironments,
         spaceId,
-        tenantTags);
+        tenantTags,
+        getId(),
+        getName(),
+        getDescription(),
+        getLinks());
   }
 
   @Override
@@ -191,6 +199,10 @@ public class TenantResource extends NamedResource {
         .append("\n");
     sb.append("    spaceId: ").append(toIndentedString(spaceId)).append("\n");
     sb.append("    tenantTags: ").append(toIndentedString(tenantTags)).append("\n");
+    sb.append("    id: ").append(toIndentedString(this.getId())).append("\n");
+    sb.append("    name: ").append(toIndentedString(this.getName())).append("\n");
+    sb.append("    description: ").append(toIndentedString(this.getDescription())).append("\n");
+    sb.append("    links: ").append(toIndentedString(this.getLinks())).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/octopus-sdk/src/main/java/com/octopus/sdk/model/user/UserResource.java
+++ b/octopus-sdk/src/main/java/com/octopus/sdk/model/user/UserResource.java
@@ -20,6 +20,7 @@ import com.octopus.sdk.model.BaseResource;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -58,4 +59,79 @@ public class UserResource extends BaseResource {
 
   @SerializedName("Username")
   private String username;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UserResource userResource = (UserResource) o;
+    return Objects.equals(this.canPasswordBeEdited, userResource.canPasswordBeEdited)
+        && Objects.equals(this.displayName, userResource.displayName)
+        && Objects.equals(this.emailAddress, userResource.emailAddress)
+        && Objects.equals(this.getId(), userResource.getId())
+        && Objects.equals(this.identities, userResource.identities)
+        && Objects.equals(this.isActive, userResource.isActive)
+        && Objects.equals(this.isRequestor, userResource.isRequestor)
+        && Objects.equals(this.isService, userResource.isService)
+        && Objects.equals(this.lastModifiedBy, userResource.lastModifiedBy)
+        && Objects.equals(this.lastModifiedOn, userResource.lastModifiedOn)
+        && Objects.equals(this.getLinks(), userResource.getLinks())
+        && Objects.equals(this.password, userResource.password)
+        && Objects.equals(this.username, userResource.username);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        canPasswordBeEdited,
+        displayName,
+        emailAddress,
+        getId(),
+        identities,
+        isActive,
+        isRequestor,
+        isService,
+        lastModifiedBy,
+        lastModifiedOn,
+        getLinks(),
+        password,
+        username);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class UserResource {\n");
+    sb.append("    canPasswordBeEdited: ")
+        .append(toIndentedString(canPasswordBeEdited))
+        .append("\n");
+    sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+    sb.append("    emailAddress: ").append(toIndentedString(emailAddress)).append("\n");
+    sb.append("    id: ").append(toIndentedString(getId())).append("\n");
+    sb.append("    identities: ").append(toIndentedString(identities)).append("\n");
+    sb.append("    isActive: ").append(toIndentedString(isActive)).append("\n");
+    sb.append("    isRequestor: ").append(toIndentedString(isRequestor)).append("\n");
+    sb.append("    isService: ").append(toIndentedString(isService)).append("\n");
+    sb.append("    lastModifiedBy: ").append(toIndentedString(lastModifiedBy)).append("\n");
+    sb.append("    lastModifiedOn: ").append(toIndentedString(lastModifiedOn)).append("\n");
+    sb.append("    links: ").append(toIndentedString(getLinks())).append("\n");
+    sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    username: ").append(toIndentedString(username)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
 }


### PR DESCRIPTION
A number of resource classes did not factor in members of their parent class when performing:
* hashcode
* equals
* toString

This change updates all resources to ensure these fields are included in said operations.