### PR TITLE
Prepare for release 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * N/A
 
 ### Bugs Resolved:
-* N/A
+* Updated Log4J dependency to mitigate Dec 2021 RCE 0-Day exploit
 
 ### Known Issues:
 * N/A

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.0.3-SNAPSHOT
+version=0.0.3
 artifactory_contextUrl=https://packages.octopushq.com/artifactory


### PR DESCRIPTION
New release with update to Log4J to address Dec 2021 0-Day RCE