### PR TITLE
Repair not publishing artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,7 @@ subprojects {
 
     if (!Arrays.asList("acceptance-tests", "examples").contains(project.name)) {
         apply plugin: 'maven-publish'
+        apply plugin: 'com.jfrog.artifactory'
 
         publishing {
             publications {


### PR DESCRIPTION
By previously removing the application of the jfrog plugin, no
artifacts were being built for send to the the maven repo.

This change re-introduces the plugin's application.