### PR TITLE
Update log4j to 2.16.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -22,7 +22,7 @@ dependencyManagement {
 
         dependency 'com.google.api-client:google-api-client:1.32.1'
 
-        dependencySet(group: 'org.apache.logging.log4j', version: '2.15.0') {
+        dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
             entry 'log4j-api'
             entry 'log4j-core'
             entry 'log4j-slf4j-impl'


### PR DESCRIPTION
Following from Log4j update, additional vulnerabilities were detected which resulted in JNDI being disabled by default.

See https://www.zdnet.com/article/second-log4j-vulnerability-found-apache-log4j-2-16-0-released/