### PR TITLE
Update log4j to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * N/A
 
 ### Bugs Resolved:
-* N/A
+* Updated Log4j to 2.17.0
 
 ### Known Issues:
 * N/A

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.0.5-SNAPSHOT
+version=0.0.5
 artifactory_contextUrl=https://packages.octopushq.com/artifactory

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -22,7 +22,7 @@ dependencyManagement {
 
         dependency 'com.google.api-client:google-api-client:1.32.1'
 
-        dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
+        dependencySet(group: 'org.apache.logging.log4j', version: '2.17.0') {
             entry 'log4j-api'
             entry 'log4j-core'
             entry 'log4j-slf4j-impl'


### PR DESCRIPTION
Additional vulnerabilities were detected in log4j, necessitating an upgrade to 2.17.0